### PR TITLE
Also look for appdata/metainfo.xml in /usr/share/metainfo

### DIFF
--- a/brp-extract-appdata.pl
+++ b/brp-extract-appdata.pl
@@ -152,7 +152,7 @@ sub read_and_extend_appdata {
 }
 
 my @appdatas;
-find( { wanted => sub { push @appdatas, $_ if /\.appdata\.xml$/ || /\.metainfo.xml$/ } , no_chdir => 1}, "usr/share/appdata/");
+find( { wanted => sub { push @appdatas, $_ if /\.appdata\.xml$/ || /\.metainfo.xml$/ } , no_chdir => 1}, "usr/share/appdata/", "usr/share/metainfo");
 
 my $output = '';
 


### PR DESCRIPTION
AppStream metainfo changed location in order to make it clear that this
meta info is no longer only for 'applications' (as appdata implied)
