### PR TITLE
fixing broken appdata metadata creation on SLE15+

### DIFF
--- a/create-appdata-xml.pl
+++ b/create-appdata-xml.pl
@@ -15,7 +15,7 @@ sub escape {
   return $d;
 }
 
-my $build_root = $::ENV{BUILD_ROOT} || '/';
+my $build_root = $::ENV{RPM_BUILD_ROOT} || '/';
 
 my $TOPDIR = '/usr/src/packages';
 $TOPDIR = '/.build.packages' if -d "$build_root/.build.packages";
@@ -57,7 +57,7 @@ exit 0 unless %appmatches;
 my %appresults;
 for my $rpm (@rpms) {
   next if $rpm =~ m/-debuginfo/ || $rpm =~ m/-debugsource/ || $rpm =~ /src\.rpm$/;
-  open (FILES, "chroot $build_root rpm -qp --qf '[%{NAME} %{FILENAMES}\n]' $rpm|");
+  open (FILES, "chroot $build_root rpm -qp --qf '%{NAME} [%{FILENAMES}\n]' $rpm|");
   my @files = <FILES>;
   chomp @files;
   close FILES;


### PR DESCRIPTION
Appdata extraction was broken on anything past SLED 12 SP4. I found out that:

- the search directory variable was wrong (should be RPM_BUILD_ROOT and not BUILD_ROOT)
- the rpm query was erroring out complaining about different array sizes, as the bracket was placed in the wrong place. It should be one element (the package name) followed by an array of file names in the package.