### PR TITLE
adding test to new variable name under SLE15+ and updated obs workers

### DIFF
--- a/brp-extract-appdata.pl
+++ b/brp-extract-appdata.pl
@@ -170,3 +170,7 @@ $type = $1 if $output =~ /(application|component)/s;
 print OUTPUT "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
 print OUTPUT $output;
 print OUTPUT "\n";
+
+chmod(0644, $outputfile);
+
+print("\nextracted appdata successfully to $outputfile\n");

--- a/create-appdata-xml.pl
+++ b/create-appdata-xml.pl
@@ -15,7 +15,7 @@ sub escape {
   return $d;
 }
 
-my $build_root = $::ENV{RPM_BUILD_ROOT} || '/';
+my $build_root = $::ENV{BUILD_ROOT} || $::ENV{RPM_BUILD_ROOT} || '/';
 
 my $TOPDIR = '/usr/src/packages';
 $TOPDIR = '/.build.packages' if -d "$build_root/.build.packages";

--- a/create-appdata-xml.pl
+++ b/create-appdata-xml.pl
@@ -17,24 +17,31 @@ sub escape {
 
 my $build_root = $::ENV{BUILD_ROOT} || $::ENV{RPM_BUILD_ROOT} || '/';
 
-my $TOPDIR = '/usr/src/packages';
-$TOPDIR = '/.build.packages' if -d "$build_root/.build.packages";
-
-open (ALL_RPMS, "chroot $build_root find $TOPDIR/RPMS/ -name \"*.rpm\" |");
-my @rpms = <ALL_RPMS>;
-chomp @rpms;
-close ALL_RPMS;
-
-my @appdata = glob("$build_root$TOPDIR/OTHER/*.applications");
+open (ALL_APPDATA, "find $build_root -type f -name \"*.applications\" | grep -v \".build.oldpackages\" |");
+my @appdata = <ALL_APPDATA>;
 if (@appdata != 1) {
   print STDERR "DEBUG: there is not a single *.applications file\n";
   exit 0;
 }
 my $appdata = shift @appdata;
-open(APPDATA, '<', $appdata) || die "can't open $appdata\n";
+
+open(APPDATA, "cat $appdata |") || die "can't open $appdata\n";
 my $content = do { local $/; <APPDATA> };
 close APPDATA;
 unlink $appdata;
+
+open(BASEDIR, "dirname $appdata |");
+my $basedir = <BASEDIR>;
+my $regex = qr/(.*\/)/mp;
+$basedir =~ /$regex/g;
+$basedir = ${^MATCH};
+chop($basedir);
+close BASEDIR;
+
+open (ALL_RPMS, "find $basedir/RPMS -type f -name \"*.rpm\" |");
+my @rpms = <ALL_RPMS>;
+chomp @rpms;
+close ALL_RPMS;
 
 # remove start and end tags
 $content =~ s/.*\n<(?:applications|components)[^\n]*>\n//s;
@@ -49,7 +56,7 @@ for (@appdatas) {
 
 my %appmatches;
 for my $ad (@appdatas) {
-  next unless $ad =~ /^    <pkgname>appdata\((.*)\)<\/pkgname>$/m;
+  next unless $ad =~ /^\s*<pkgname>appdata\((.*)\)<\/pkgname>$/m;
   $appmatches{"/usr/share/appdata/$1"} = $ad;
 }
 exit 0 unless %appmatches;
@@ -57,26 +64,27 @@ exit 0 unless %appmatches;
 my %appresults;
 for my $rpm (@rpms) {
   next if $rpm =~ m/-debuginfo/ || $rpm =~ m/-debugsource/ || $rpm =~ /src\.rpm$/;
-  open (FILES, "chroot $build_root rpm -qp --qf '%{NAME} [%{FILENAMES}\n]' $rpm|");
+  open (FILES, "rpm -qp --qf '%{NAME} [%{FILENAMES}\n]' $rpm |");
   my @files = <FILES>;
   chomp @files;
   close FILES;
   # ignore empty rpm as rpmlint will catch them
   @files = grep {!/^\(none\)/} @files;
+
   for my $file (@files) {
     next unless $file =~ /^(\S+) (.*)$/;
     my $rpmname = $1;
     my $rpmfile = $2;
-    my $ad = $appmatches{$rpmfile};
-    next unless $ad;
-    my $rpmnamex = escape($rpmname);
-    next unless $ad =~ s/^    <pkgname>appdata\((.*)\)<\/pkgname>$/    <pkgname>$rpmnamex<\/pkgname>/m;
-    push @{$appresults{$rpmname}}, $ad;
-  }
+    for my $ad (%appmatches) {
+        my $rpmnamex = escape($rpmname);
+        next unless $ad =~ s/^\s*<pkgname>appdata\((.*)\)<\/pkgname>$/    <pkgname>$rpmnamex<\/pkgname>/m;
+        push @{$appresults{$rpmname}}, $ad};
+    }
 }
 
+my $output = '';
 for my $rpmname (sort keys %appresults) {
-  my $output = "$build_root$TOPDIR/OTHER/$rpmname.appdata.xml";
+  $output = "$basedir/OTHER/$rpmname.appdata.xml";
   open(APPDATA, '>', $output) || die "can't write to $output";
   print APPDATA "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
   my $type = 'component';
@@ -84,3 +92,5 @@ for my $rpmname (sort keys %appresults) {
   print APPDATA $_ for @{$appresults{$rpmname}};
   close APPDATA;
 }
+
+print("found appdata at $output\n");


### PR DESCRIPTION
After updating OBS workers to the latest version, I found out that appdata was NOT being extracted from SLE15+ and openSUSE Leap 15+ clients. Instead, we're left with a plain <appname>.applications file in the results, and no AppData information is generated in repodata.

Debugging the problem, I noticed that apparently there is no more RPM_BUILD_ROOT variable, which the create-appdata-xml.pl script depends on to find the appdata. On the updated OBS workers, we have a "BUILD_ROOT" variable. I just added an extra check for this variable name and use it if it exists.

